### PR TITLE
I've been working on fixing various errors and adding diagnostics for…

### DIFF
--- a/grazr/main.py
+++ b/grazr/main.py
@@ -1,4 +1,13 @@
 import sys
+print(f"DEBUG: sys.executable: {sys.executable}")
+print(f"DEBUG: sys.path: {sys.path}")
+try:
+    import qtpy
+    print("DEBUG: qtpy imported successfully")
+except ImportError as e:
+    print(f"DEBUG: Failed to import qtpy: {e}")
+
+import sys
 import os
 import traceback
 from pathlib import Path
@@ -284,18 +293,19 @@ if __name__ == "__main__":
     logger.info("Applied global stylesheet.")
 
     # --- Create the Main Window ---
-    logger.info("MAIN: Creating MainWindow instance...")
+    logger.info("MAIN: MainWindow instantiation starting...") # Changed log message slightly for clarity
     window: Optional['MainWindow'] = None # Initialize with Optional and forward reference for MainWindow
     try:
         window = MainWindow() # MainWindow type hint will be resolved by linter
         main_window_instance = window
+        logger.info("MAIN: MainWindow instantiation completed.") # Added log after successful instantiation
     except Exception as e:
         logger.critical(f"MAIN: Error during MainWindow creation: {e}", exc_info=True)
         # traceback.print_exc() # logger.critical with exc_info=True already does this
         sys.exit(1) # Exit if main window can't be created
 
     if tray_icon and window: window.set_tray_icon(tray_icon) # Check window is not None
-    logger.info("MAIN: MainWindow instance created successfully.")
+    # logger.info("MAIN: MainWindow instance created successfully.") # Covered by the one in try block
 
     # --- Connect Signals Between Tray and Window ---
     if tray_icon and window: # Ensure window is not None

--- a/grazr/ui/generic_service_detail_widget.py
+++ b/grazr/ui/generic_service_detail_widget.py
@@ -15,21 +15,49 @@ logger = logging.getLogger(__name__)
 try:
     # Assuming generic_service_detail_widget.py is in grazr/ui/
     # and config.py is in grazr/core/
-    from grazr.core.config import ServiceDefinition, config # Import both ServiceDefinition and the config object
+    from grazr.core.config import (
+        ServiceDefinition,
+        MINIO_CONSOLE_PORT,
+        MINIO_DEFAULT_ROOT_USER,
+        MINIO_DEFAULT_ROOT_PASSWORD,
+        POSTGRES_DEFAULT_USER_VAR,
+        POSTGRES_DEFAULT_DB,
+        NGINX_PROCESS_ID,
+        INTERNAL_NGINX_ERROR_LOG,
+        # Add other potential log_file_template_name values if identifiable
+        # For now, this list covers direct uses and one common dynamic lookup.
+        # If more dynamic lookups are common, they'd need to be added or config_module used.
+        INTERNAL_POSTGRES_INSTANCE_LOG_TEMPLATE
+    )
+    # Import the config module itself for dynamic hasattr/getattr
+    from grazr.core import config as core_config_module
+
 except ImportError:
     logger.warning("GenericServiceDetailWidget: Could not import ServiceDefinition or core.config. Some defaults might be missing or type hints incomplete.")
     # Define a dummy ServiceDefinition for type hinting if import fails
     class ServiceDefinition:
         def __init__(self, *args, **kwargs): pass # Basic dummy
+
     class ConfigDummy: # Minimal dummy for attributes that might be used as fallbacks
         MINIO_CONSOLE_PORT = 9001
         MINIO_DEFAULT_ROOT_USER = "minioadmin"
         MINIO_DEFAULT_ROOT_PASSWORD = "minioadmin"
         POSTGRES_DEFAULT_USER_VAR = "postgres"
         POSTGRES_DEFAULT_DB = "postgres"
-        NGINX_PROCESS_ID = "internal-nginx" # Added for _get_log_path_for_service_internal
-        INTERNAL_NGINX_ERROR_LOG = Path("/tmp/dummy_nginx_error.log") # Added for _get_log_path_for_service_internal
-    config = ConfigDummy()
+        NGINX_PROCESS_ID = "internal-nginx"
+        INTERNAL_NGINX_ERROR_LOG = Path("/tmp/dummy_nginx_error.log")
+        INTERNAL_POSTGRES_INSTANCE_LOG_TEMPLATE = "/tmp/dummy_pg_{instance_id}.log" # Dummy for the dynamic lookup
+
+    core_config_module = ConfigDummy() # Fallback for the module alias
+    # Also define fallbacks for directly imported constants if needed by dummy logic below
+    MINIO_CONSOLE_PORT = core_config_module.MINIO_CONSOLE_PORT
+    MINIO_DEFAULT_ROOT_USER = core_config_module.MINIO_DEFAULT_ROOT_USER
+    MINIO_DEFAULT_ROOT_PASSWORD = core_config_module.MINIO_DEFAULT_ROOT_PASSWORD
+    POSTGRES_DEFAULT_USER_VAR = core_config_module.POSTGRES_DEFAULT_USER_VAR
+    POSTGRES_DEFAULT_DB = core_config_module.POSTGRES_DEFAULT_DB
+    NGINX_PROCESS_ID = core_config_module.NGINX_PROCESS_ID
+    INTERNAL_NGINX_ERROR_LOG = core_config_module.INTERNAL_NGINX_ERROR_LOG
+    INTERNAL_POSTGRES_INSTANCE_LOG_TEMPLATE = core_config_module.INTERNAL_POSTGRES_INSTANCE_LOG_TEMPLATE
 
 
 class GenericServiceDetailWidget(QWidget):
@@ -325,8 +353,8 @@ class GenericServiceDetailWidget(QWidget):
             lines.extend([f"DB_CONNECTION=mysql", f"DB_HOST={host}", f"DB_PORT={configured_port}",
                           f"DB_DATABASE=your_database_name", f"DB_USERNAME=root", f"DB_PASSWORD=your_password"])
         elif service_type and service_type.startswith("postgres"): # Handles "postgres14", "postgres15", etc.
-            db_user = getattr(config, 'POSTGRES_DEFAULT_USER_VAR', 'postgres') # Default DB user from config
-            db_name = getattr(config, 'POSTGRES_DEFAULT_DB', 'postgres')     # Default DB name from config
+            db_user = POSTGRES_DEFAULT_USER_VAR # Default DB user from config
+            db_name = POSTGRES_DEFAULT_DB     # Default DB name from config
             lines.extend([f"DB_CONNECTION=pgsql", f"DB_HOST={host}", f"DB_PORT={configured_port}",
                           f"DB_DATABASE={db_name}", f"DB_USERNAME={db_user}", f"DB_PASSWORD=your_password"])
         elif service_type == "redis":
@@ -334,14 +362,14 @@ class GenericServiceDetailWidget(QWidget):
         elif service_type == "minio":
             api_port = configured_port
             # Use getattr for console_port from service_definition as it might not always exist
-            console_port = getattr(self._service_definition, 'console_port', None)
-            if console_port is None: # Fallback to global config if not on definition
-                 console_port = getattr(config, 'MINIO_CONSOLE_PORT', 9001)
+            console_port_val = getattr(self._service_definition, 'console_port', None)
+            if console_port_val is None: # Fallback to global config if not on definition
+                 console_port_val = MINIO_CONSOLE_PORT
 
-            user = getattr(config, 'MINIO_DEFAULT_ROOT_USER', 'grazrMinioUser') # Fallback values
-            password = getattr(config, 'MINIO_DEFAULT_ROOT_PASSWORD', 'grazrMinioPassword')
+            user = MINIO_DEFAULT_ROOT_USER # Fallback values
+            password = MINIO_DEFAULT_ROOT_PASSWORD
             bucket_name = "your-bucket-name"
-            lines.extend([f"# MinIO Console: http://{host}:{console_port}",
+            lines.extend([f"# MinIO Console: http://{host}:{console_port_val}",
                           f"MINIO_ENDPOINT={host}:{api_port}", f"MINIO_ACCESS_KEY={user}",
                           f"MINIO_SECRET_KEY={password}", f"MINIO_BUCKET={bucket_name}",
                           f"MINIO_USE_SSL=false", f"# For AWS SDK compatible settings:",
@@ -375,18 +403,18 @@ class GenericServiceDetailWidget(QWidget):
         # Case 2: Log path template on ServiceDefinition (e.g., PostgreSQL instances)
         elif getattr(self._service_definition, 'log_file_template_name', None) and instance_specific_id:
             template_name = self._service_definition.log_file_template_name
-            if hasattr(config, template_name):
-                template_str = getattr(config, template_name)
+            if hasattr(core_config_module, template_name):
+                template_str = getattr(core_config_module, template_name)
                 try:
                     log_path = Path(template_str.format(instance_id=instance_specific_id))
                 except KeyError as e:
                     logger.error(f"Missing placeholder for log template {template_name}: {e}")
             else:
-                logger.error(f"Log template name '{template_name}' not found in config.")
+                logger.error(f"Log template name '{template_name}' not found in config module.")
         # Case 3: Fallback for Nginx using its specific config constant if service_id matches
         # This might be redundant if service_definition.log_path is correctly set for Nginx
-        elif service_id_from_config == config.NGINX_PROCESS_ID and hasattr(config, 'INTERNAL_NGINX_ERROR_LOG'):
-            log_path = config.INTERNAL_NGINX_ERROR_LOG
+        elif service_id_from_config == NGINX_PROCESS_ID: # Use imported constant
+            log_path = INTERNAL_NGINX_ERROR_LOG # Use imported constant
 
         if log_path:
             self.open_log_button.setVisible(log_path.exists())
@@ -459,8 +487,8 @@ if __name__ == '__main__':
         default_port=5432, db_client_tools=["psql", "pg_dump"]
     )
     # Add dummy template to config for testing postgres log path
-    if isinstance(config, ConfigDummy): # Check if using ConfigDummy
-        config.TEST_PG_LOG_TEMPLATE = "/tmp/pg_{instance_id}.log"
+    if isinstance(core_config_module, ConfigDummy): # Check if using ConfigDummy
+        core_config_module.TEST_PG_LOG_TEMPLATE = "/tmp/pg_{instance_id}.log"
 
 
     service_conf1 = {"id": "nginx_process_id1", "service_type": "nginx", "name": "My Nginx Server", "port": 80}

--- a/grazr/ui/main_window.py
+++ b/grazr/ui/main_window.py
@@ -113,6 +113,7 @@ class MainWindow(QMainWindow):
 
     def __init__(self):
         super().__init__()
+        logger.info("MainWindow.__init__: Start")
 
         self.tray_icon = None
         self.setWindowTitle(f"{getattr(config, 'APP_NAME', 'Grazr')} (Alpha)")
@@ -157,10 +158,19 @@ class MainWindow(QMainWindow):
         content_layout.addWidget(stack_container, 1) # Stack container takes expanding space
 
         # --- Create Page Instances ---
+        logger.info("MainWindow.__init__: Creating ServicesPage...")
         self.services_page = ServicesPage(self)
+        logger.info("MainWindow.__init__: ServicesPage created.")
+        logger.info("MainWindow.__init__: Creating PhpPage...")
         self.php_page = PhpPage(self)
+        logger.info("MainWindow.__init__: PhpPage created.")
+        logger.info("MainWindow.__init__: Creating SitesPage...")
         self.sites_page = SitesPage(self)
+        logger.info("MainWindow.__init__: SitesPage created.")
+        logger.info("MainWindow.__init__: Creating NodePage...")
         self.node_page = NodePage(self)
+        logger.info("MainWindow.__init__: NodePage created.")
+
         self.stacked_widget.addWidget(self.services_page)
         self.stacked_widget.addWidget(self.php_page)
         self.stacked_widget.addWidget(self.sites_page)
@@ -220,6 +230,7 @@ class MainWindow(QMainWindow):
         self.log_message("Attempting to start bundled Nginx...")
         QTimer.singleShot(100, lambda: self.triggerWorker.emit("start_internal_nginx", {}))
         self.start_configured_autostart_services()
+        logger.info("MainWindow.__init__: End")
 
     def set_tray_icon(self, tray_icon: QSystemTrayIcon):
         self.tray_icon = tray_icon

--- a/grazr/ui/node_page.py
+++ b/grazr/ui/node_page.py
@@ -47,6 +47,7 @@ class NodePage(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        logger.info(f"{self.__class__.__name__}.__init__: Start")
         self._main_window = parent
         self.setObjectName("NodePage")
 
@@ -101,6 +102,7 @@ class NodePage(QWidget):
         # Initial Data Load is handled by MainWindow when page becomes visible,
         # or can be triggered here if needed immediately.
         # QTimer.singleShot(100, self.refresh_data)
+        logger.info(f"{self.__class__.__name__}.__init__: End")
 
     # --- Header Action Methods ---
     def add_header_actions(self, header_widget): # Changed parameter
@@ -178,7 +180,7 @@ class NodePage(QWidget):
         # Check if self is still valid
         try: _ = self.objectName()
         except RuntimeError: return # Widget deleted
-
+        logger.info(f"{self.__class__.__name__}.refresh_data: Start")
         self.log_to_main(f"NodePage: Refresh data called (is_first_load={self._is_first_load})")
         self.set_controls_enabled(False)
 
@@ -217,6 +219,7 @@ class NodePage(QWidget):
         self._is_first_load = False
         self.set_controls_enabled(True)
         # Buttons are updated by VersionListPanelWidget itself based on selection
+        logger.info(f"{self.__class__.__name__}.refresh_data: End")
 
     # --- Add method to clear cache (called by MainWindow after install/uninstall) ---
     def clear_installed_cache(self):
@@ -228,6 +231,7 @@ class NodePage(QWidget):
     @Slot(bool)
     def set_controls_enabled(self, enabled: bool):
         """Enable/disable controls on the page, including the new panels."""
+        logger.debug(f"{self.__class__.__name__}: set_controls_enabled called with {enabled}.") # No timer here
         self.available_versions_panel.set_controls_enabled(enabled)
         self.installed_versions_panel.set_controls_enabled(enabled)
         # The refresh button is part of the header, managed by MainWindow or HeaderWidget based on page state.

--- a/grazr/ui/php_page.py
+++ b/grazr/ui/php_page.py
@@ -31,7 +31,9 @@ try:
     from .widgets.php_version_item_widget import PhpVersionItemWidget
     from .common_php_ini_settings_widget import CommonPhpIniSettingsWidget # Import new widget
 except ImportError as e:
-    print(f"ERROR in php_page.py: Could not import from core/managers or local widgets: {e}")
+    # This print will use the logger if the logger was successfully initialized before the error.
+    # If not, it will print to stdout/stderr.
+    logger.error(f"ERROR in php_page.py: Could not import from core/managers or local widgets: {e}", exc_info=True)
     # Define dummy functions/constants
     def detect_bundled_php_versions(): return ["?.?(ImportErr)"]
     def get_php_fpm_status(v): return "unknown"
@@ -41,8 +43,16 @@ except ImportError as e:
 
     class PhpVersionItemWidget(QWidget):
         actionClicked = Signal(str, str); configureClicked = Signal(str)
-        def update_status(s): pass;
-    pass
+        def update_status(self, status_text: str): pass # Added self and type hint
+        def set_controls_enabled(self, enabled: bool): pass # Added self and type hint
+
+    class CommonPhpIniSettingsWidget(QWidget): # Dummy for CommonPhpIniSettingsWidget
+        saveIniSettingsClicked = Signal(str, dict)
+        def __init__(self, parent=None): super().__init__(parent)
+        def update_settings_for_version(self, version: str | None): pass
+        def set_controls_enabled(self, enabled: bool): pass
+
+
     # Dummy config needed if direct constants are used (currently only DEFAULT_PHP)
     # class ConfigDummy: DEFAULT_PHP="default"; config = ConfigDummy()
 # --- End Imports ---
@@ -56,6 +66,7 @@ class PhpPage(QWidget):
     def __init__(self, parent=None):
         """Initializes the PHP management page UI."""
         super().__init__(parent)
+        logger.info(f"{self.__class__.__name__}.__init__: Start")
         self._main_window = parent
         # Key: version string, Value: PhpVersionItemWidget instance
         self.version_widgets = {}
@@ -98,6 +109,7 @@ class PhpPage(QWidget):
         # --- End INI Settings Section ---
 
         main_layout.addStretch(1) # Add stretch after all content widgets
+        logger.info(f"{self.__class__.__name__}.__init__: End")
 
     # --- Header Action Methods ---
     def add_header_actions(self, header_widget):
@@ -151,6 +163,7 @@ class PhpPage(QWidget):
 
     def refresh_data(self):
         """Called by MainWindow to reload PHP version data and status."""
+        logger.info(f"{self.__class__.__name__}.refresh_data: Start")
         # Check if self is still valid before proceeding
         try: _ = self.objectName()
         except RuntimeError: print("DEBUG PhpPage: refresh_data called on deleted widget."); return
@@ -202,6 +215,7 @@ class PhpPage(QWidget):
             else: # Should not happen if available_versions is not empty
                 self.common_ini_settings_widget.update_settings_for_version(None)
                 self.common_ini_settings_widget.setEnabled(False)
+        logger.info(f"{self.__class__.__name__}.refresh_data: End")
 
 
     def _load_ini_values_for_display(self, version: str | None):
@@ -215,6 +229,7 @@ class PhpPage(QWidget):
         self.log_to_main(f"PhpPage: Updating common INI settings display for PHP {version}")
         self.common_ini_settings_widget.update_settings_for_version(version)
         self.common_ini_settings_widget.setEnabled(True) # Ensure it's enabled if a version is selected
+        # logger.info(f"{self.__class__.__name__}.refresh_data: End") # This was the misplaced log line, it should be at the end of refresh_data
 
     # Removed _parse_mb_value, it's now in CommonPhpIniSettingsWidget
 
@@ -237,7 +252,8 @@ class PhpPage(QWidget):
         if enabled:
             # If enabling controls, refresh data to get latest statuses.
             # CommonPhpIniSettingsWidget handles its own save button state based on changes.
-            QTimer.singleShot(10, self.refresh_data)
+            # QTimer.singleShot(10, self.refresh_data) # Commented out for hang investigation
+            logger.debug(f"{self.__class__.__name__}: set_controls_enabled called with {enabled}, refresh_data timer commented out.")
         # No specific action for save button here; CommonPhpIniSettingsWidget manages it.
 
 

--- a/grazr/ui/site_config_panel.py
+++ b/grazr/ui/site_config_panel.py
@@ -15,13 +15,17 @@ logger = logging.getLogger(__name__)
 
 # Try to import manager functions, with fallbacks for standalone testing
 try:
-    from grazr.core import config # To get DEFAULT_PHP, DEFAULT_NODE, SITE_TLD
+    from grazr.core.config import DEFAULT_PHP, DEFAULT_NODE, SITE_TLD
     from grazr.managers.php_manager import detect_bundled_php_versions, get_default_php_version
     from grazr.managers.node_manager import list_installed_node_versions
 except ImportError:
     logger.warning("SITE_CONFIG_PANEL: Could not import manager functions. Using dummies for standalone testing.")
-    class ConfigDummy: DEFAULT_PHP = "default"; DEFAULT_NODE = "system"; SITE_TLD = "test"
-    config = ConfigDummy()
+    # Define fallbacks for directly imported constants
+    DEFAULT_PHP = "default"
+    DEFAULT_NODE = "system"
+    SITE_TLD = "test"
+    # class ConfigDummy: DEFAULT_PHP = "default"; DEFAULT_NODE = "system"; SITE_TLD = "test" # No longer needed
+    # config = ConfigDummy() # No longer needed
     def detect_bundled_php_versions(): return ["7.4", "8.1", "8.3"]
     def get_default_php_version(): return "8.1"
     def list_installed_node_versions(): return ["18.17.0", "20.9.0"]
@@ -128,8 +132,8 @@ class SiteConfigPanel(QWidget):
         if self._available_php_versions:
             self.php_version_combo.addItems(self._available_php_versions)
 
-        stored_php = self._site_info.get('php_version', config.DEFAULT_PHP)
-        if stored_php == config.DEFAULT_PHP or stored_php is None: # Handle None explicitly
+        stored_php = self._site_info.get('php_version', DEFAULT_PHP) # Use imported constant
+        if stored_php == DEFAULT_PHP or stored_php is None: # Handle None explicitly
             self.php_version_combo.setCurrentText("Default")
         else:
             self.php_version_combo.setCurrentText(stored_php)
@@ -141,8 +145,8 @@ class SiteConfigPanel(QWidget):
         self.refresh_node_button.setVisible(needs_node)
         if needs_node:
             self._populate_node_versions() # Populates and sets current value
-            stored_node = self._site_info.get('node_version', config.DEFAULT_NODE)
-            if stored_node == config.DEFAULT_NODE or stored_node is None:
+            stored_node = self._site_info.get('node_version', DEFAULT_NODE) # Use imported constant
+            if stored_node == DEFAULT_NODE or stored_node is None:
                 self.node_version_combo.setCurrentText("System")
             else:
                  self.node_version_combo.setCurrentText(stored_node)
@@ -158,12 +162,12 @@ class SiteConfigPanel(QWidget):
 
         # URL/Domain
         self.url_edit.setText(self._site_info.get('domain', ''))
-        site_tld = getattr(config, 'SITE_TLD', 'test')
-        regex_pattern = f"^[a-zA-Z0-9-]+(\\.{re.escape(site_tld)})$"
+        # site_tld = getattr(config, 'SITE_TLD', 'test') # Use imported constant
+        regex_pattern = f"^[a-zA-Z0-9-]+(\\.{re.escape(SITE_TLD)})$" # Use imported constant
         domain_regex = QRegularExpression(regex_pattern)
         validator = QRegularExpressionValidator(domain_regex, self.url_edit)
         self.url_edit.setValidator(validator)
-        self.url_edit.setPlaceholderText(f"site.{site_tld}")
+        self.url_edit.setPlaceholderText(f"site.{SITE_TLD}") # Changed site_tld to SITE_TLD
         self.save_url_button.setEnabled(False) # Disable save on update
 
         logger.debug(f"SiteConfigPanel updated for site: {self._site_info.get('domain', 'N/A')}")
@@ -198,8 +202,8 @@ class SiteConfigPanel(QWidget):
     @Slot(str)
     def _on_php_version_changed(self, selected_text: str):
         if not self._site_info: return
-        stored_version = self._site_info.get('php_version', config.DEFAULT_PHP)
-        version_to_save = config.DEFAULT_PHP if selected_text == "Default" else selected_text
+        stored_version = self._site_info.get('php_version', DEFAULT_PHP) # Use imported constant
+        version_to_save = DEFAULT_PHP if selected_text == "Default" else selected_text # Use imported constant
 
         if version_to_save != stored_version:
             logger.info(f"PHP version change requested for '{self._site_info.get('domain')}': '{version_to_save}'")
@@ -208,8 +212,8 @@ class SiteConfigPanel(QWidget):
     @Slot(str)
     def _on_node_version_changed(self, selected_text: str):
         if not self._site_info or not self._site_info.get('needs_node', False) : return
-        stored_version = self._site_info.get('node_version', config.DEFAULT_NODE)
-        version_to_save = config.DEFAULT_NODE if selected_text == "System" else selected_text
+        stored_version = self._site_info.get('node_version', DEFAULT_NODE) # Use imported constant
+        version_to_save = DEFAULT_NODE if selected_text == "System" else selected_text # Use imported constant
 
         if version_to_save != stored_version:
             logger.info(f"Node version change requested for '{self._site_info.get('domain')}': '{version_to_save}'")

--- a/grazr/ui/sites_page.py
+++ b/grazr/ui/sites_page.py
@@ -1,5 +1,4 @@
-import logging # Added for logger
-import logging # Added for logger
+import logging # Keep one logging import
 import sys # Added for F821
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
                                QPushButton, QListWidget, QListWidgetItem,
@@ -15,6 +14,8 @@ import shutil
 import shlex # Keep for terminal command quoting
 # import traceback # Removed F401
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # --- Import Core Config and Manager Modules (using new paths) ---
 try:
@@ -71,6 +72,7 @@ class SitesPage(QWidget):
     def __init__(self, parent=None):
         """Initializes the Sites page UI with master-detail layout."""
         super().__init__(parent)
+        logger.info(f"{self.__class__.__name__}.__init__: Start")
         self._main_window = parent
         self.current_site_info = None
         self._available_php_versions = []
@@ -168,6 +170,7 @@ class SitesPage(QWidget):
         # --- Initial State ---
         self._fetch_initial_versions() # Fetch PHP and Node versions once
         self.display_site_details(None) # Show placeholder
+        logger.info(f"{self.__class__.__name__}.__init__: End")
 
     # --- Header Action Methods ---
     def add_header_actions(self, header_widget):
@@ -605,6 +608,7 @@ class SitesPage(QWidget):
 
     def refresh_data(self):
         """Refresh site list and current details."""
+        logger.info(f"{self.__class__.__name__}.refresh_data: Start")
         try:
             # First refresh the sites list
             self.refresh_site_list()
@@ -614,16 +618,18 @@ class SitesPage(QWidget):
             if current_item:
                 self.display_site_details(current_item)
             else:
-                # No item selected, show placeholder
-                self._show_details_placeholder("Select a site from the list on the left.")
+                # No item selected, show placeholder (handled by display_site_details(None))
+                self.display_site_details(None) # Changed from _show_details_placeholder
         except Exception as e:
-            print(f"Error in SitesPage.refresh_data: {e}")
-            traceback.print_exc()
+            # print(f"Error in SitesPage.refresh_data: {e}") # Replaced with logger
+            # traceback.print_exc() # Replaced with logger
+            logger.error(f"Error in SitesPage.refresh_data: {e}", exc_info=True)
 
             # Attempt to show placeholder as fallback if SiteDetailWidget fails to render
             if hasattr(self, 'site_detail_widget') and self.site_detail_widget:
                  self.site_detail_widget.update_details(None, [], []) # Clear it
-            logger.error(f"Error in SitesPage.refresh_data, attempting to clear details: {e}", exc_info=True)
+            # logger.error(f"Error in SitesPage.refresh_data, attempting to clear details: {e}", exc_info=True) # Already logged above
+        logger.info(f"{self.__class__.__name__}.refresh_data: End")
 
 
     @Slot(str)
@@ -650,7 +656,8 @@ class SitesPage(QWidget):
 
         # If enabling, refresh data to ensure states are correct
         if enabled:
-            self.refresh_data() # This will also call update_details on SiteDetailWidget
+            # self.refresh_data() # This will also call update_details on SiteDetailWidget # Commented out for hang investigation
+            logger.debug(f"{self.__class__.__name__}: set_controls_enabled called with {enabled}, refresh_data timer commented out.")
 
     # _set_detail_widget_enabled is no longer needed as SiteDetailWidget/SiteConfigPanel manage their own internal states.
 


### PR DESCRIPTION
… issues related to 'hang' and 'qtpy'.

Here's a summary of what I've done:
- Corrected various ImportErrors, NameErrors, and AttributeErrors.
- Addressed linting issues across your codebase.
- Attempted to resolve Qt XCB platform plugin errors by installing dependencies.
- Changed relative imports to absolute imports, and then to direct constant imports for config values to resolve warnings.
- Added diagnostic code to grazr/main.py to debug a persistent 'ModuleNotFoundError: No module named 'qtpy''. This code prints sys.executable, sys.path, and the result of a qtpy import attempt.
- Added extensive logging to MainWindow and UI page initialization and refresh_data methods to trace execution flow.
- Temporarily commented out QTimer.singleShot calls in set_controls_enabled methods as a potential source of an application hang.

The application currently hangs during startup when run with `python -m grazr.main` (even with QT_QPA_PLATFORM="minimal"). Unfortunately, due to timeouts in my current environment, I wasn't able to capture the detailed diagnostic logs I added to pinpoint the hang and the qtpy diagnostics in my last attempt.

Here's what I think needs to happen next:
1. I need to capture logs from the hanging application to identify the point of failure.
2. I need to resolve the application hang.
3. I need to analyze the qtpy diagnostic output and resolve the ModuleNotFoundError.
4. I need to fully test the application, including with its intended GUI.