### PR TITLE
I've worked on handling Node.js services more gracefully and improvin…

### DIFF
--- a/grazr/ui/main_window.py
+++ b/grazr/ui/main_window.py
@@ -520,7 +520,9 @@ class MainWindow(QMainWindow):
         if target_page and hasattr(target_page, 'set_controls_enabled'):
             logger.debug(f"MAIN_WINDOW: Scheduling {target_page.__class__.__name__}.set_controls_enabled(True)")
             re_enable_delay = refresh_delay + 150 if not self.progress_dialog else 100
-            QTimer.singleShot(re_enable_delay, lambda: target_page.set_controls_enabled(True))
+            # Modified lambda to check if target_page is still valid and visible
+            QTimer.singleShot(re_enable_delay,
+                              lambda page=target_page: page.set_controls_enabled(True) if page and hasattr(page, 'isVisible') and page.isVisible() else None)
         else:
             logger.debug(f"MAIN_WINDOW: NOT scheduling re-enable for task '{task_name}'.")
         self.log_message("-" * 30)

--- a/grazr/ui/service_item_widget.py
+++ b/grazr/ui/service_item_widget.py
@@ -138,6 +138,40 @@ class ServiceItemWidget(QWidget):
     @Slot(str)
     def update_status(self, status):
         self._current_status = status
+        process_id_for_pm = self.property("process_id_for_pm")
+
+        if process_id_for_pm == "nvm_managed":
+            self._current_status = "nvm_managed" # Special status
+            if hasattr(self, 'status_indicator'):
+                # Consider adding a specific color/icon for 'nvm_managed' in StatusIndicator
+                self.status_indicator.set_color(Qt.GlobalColor.darkCyan)
+            if hasattr(self, 'detail_label'):
+                self.detail_label.setText("Managed via Node Page")
+
+            if hasattr(self, 'action_button'):
+                self.action_button.setText("N/A")
+                self.action_button.setEnabled(False)
+                self.action_button.setToolTip("Node.js is managed via NVM on the Node Page.")
+
+            if hasattr(self, 'remove_button'):
+                # NVM as a core component is not typically "removed" via service list.
+                # If this widget represents a specific user-added "node service instance" (unlikely for NVM),
+                # then removal logic might apply. For now, assume it's the core NVM entry.
+                self.remove_button.setVisible(False)
+
+            if hasattr(self, 'settings_button'):
+                self.settings_button.setToolTip("Manage Node.js versions on the Node Page")
+                # Optionally, make settings button navigate to Node page if MainWindow handles such a signal
+
+            # Ensure UI updates for these specific changes
+            for btn_widget in [self.action_button, self.remove_button, self.settings_button, self.detail_label, getattr(self, 'status_indicator', None)]:
+                if btn_widget and hasattr(btn_widget, 'update'):
+                    try:
+                        btn_widget.update()
+                    except RuntimeError: pass # Widget might be deleting
+            return
+
+        # Original status logic for other services
         status_color = Qt.GlobalColor.gray
         button_text = "Start"
         action_enabled = False


### PR DESCRIPTION
…g runtime error safeguards.

This involved:
- Modifications in `grazr/core/config.py` to ensure the Node.js `ServiceDefinition` has `process_id = None`.
- Changes in `grazr/ui/services_page.py` (within `refresh_data`) to detect 'node' type services. If a `process_id` isn't found, it assigns a special string "nvm_managed" to `process_id_for_pm` and ensures a `ServiceItemWidget` is still created, suppressing the "Cannot determine process_id_for_pm" warning for this type.
- Updates to `grazr/ui/service_item_widget.py` to recognize the "nvm_managed" `process_id_for_pm`. For such items, it adjusts UI elements: start/stop/remove buttons are hidden/disabled, and status is displayed appropriately (e.g., "Managed by NVM").
- Proactive checks added to a `QTimer.singleShot` in `grazr/ui/main_window.py` (in `handleWorkerResult`) to call `target_page.set_controls_enabled(True)` only if the target page still exists and is visible. This is an attempt to mitigate `RuntimeError: Internal C++ object already deleted`.
- Existing `try-except RuntimeError` blocks in `ServicesPage.set_controls_enabled` were kept as a final safeguard.

Previously, I addressed issues including:
- Various ImportErrors, NameErrors, and AttributeErrors (including for `ServiceDefinition.get`).
- Linting errors.
- Attempts to resolve Qt XCB platform issues.
- Extensive diagnostic logging for startup and `qtpy` issues.

CRITICAL UNRESOLVED ISSUE:
The application currently hangs during startup when run with `python -m grazr.main` (even with `QT_QPA_PLATFORM="minimal"`). Due to command timeouts in the execution environment, I couldn't capture output (including critical diagnostic logs for the hang and confirmation of these latest fixes).

Further work is critically needed to:
1.  **Capture logs from the hanging application.** This is the highest priority. One method could be redirecting stdout/stderr to a file during execution and examining it afterwards.
2.  Resolve the application hang.
3.  Analyze `qtpy` diagnostic output (once obtainable) and resolve any `ModuleNotFoundError`.
4.  Fully test all applied fixes and the application's UI once the hang and Qt platform issues are resolved.