### PR TITLE
I've worked on fixing a `RuntimeError` in the Header and enhancing lo…

### DIFF
--- a/grazr/ui/services_page.py
+++ b/grazr/ui/services_page.py
@@ -468,7 +468,7 @@ class ServicesPage(QWidget):
                 else:
                     logger.debug(f"SERVICES_PAGE: add_service_button has no parent in set_controls_enabled, skipping.")
             except RuntimeError as e:
-                logger.warning(f"SERVICES_PAGE: RuntimeError accessing add_service_button in set_controls_enabled: {e}")
+                logger.warning(f"SERVICES_PAGE: RuntimeError accessing add_service_button (intended state: {enabled}) in set_controls_enabled: {e}")
 
         if hasattr(self, 'stop_all_button') and self.stop_all_button:
             try:
@@ -477,7 +477,7 @@ class ServicesPage(QWidget):
                 else:
                     logger.debug(f"SERVICES_PAGE: stop_all_button has no parent in set_controls_enabled, skipping.")
             except RuntimeError as e:
-                logger.warning(f"SERVICES_PAGE: RuntimeError accessing stop_all_button in set_controls_enabled: {e}")
+                logger.warning(f"SERVICES_PAGE: RuntimeError accessing stop_all_button (intended state: {enabled}) in set_controls_enabled: {e}")
 
         # The QTimer.singleShot that called refresh_data was already commented out in a previous step.
         logger.debug(f"{self.__class__.__name__}: set_controls_enabled called with {enabled}, refresh_data timer commented out.")


### PR DESCRIPTION
…gging in the ServicePage.

Here's what I did:
- In `grazr/ui/header.py`, within the `clear_actions` method, I added `try-except RuntimeError` blocks. I also included checks to ensure a widget exists before attempting to remove or delete it. This should prevent crashes if widgets are already gone.
- In `grazr/ui/services_page.py`, within the `set_controls_enabled` method, I improved the log messages. If a `RuntimeError` occurs when accessing the `add_service_button` or `stop_all_button`, the log will now show the intended `enabled` state, which should help with debugging.

I've previously addressed several other issues, including:
- Handling Node.js services on the ServicesPage.
- Fixing AttributeErrors related to ServiceDefinition.
- Initial safeguards for RuntimeErrors in the ServicesPage.
- Various ImportErrors and NameErrors.
- Linting errors.
- Attempts to resolve Qt XCB platform plugin errors.
- Adding extensive diagnostic logging for startup and `qtpy` issues.

However, there's a CRITICAL UNRESOLVED ISSUE:
The application currently hangs during startup when you run `python -m grazr.main` (even with `QT_QPA_PLATFORM="minimal"`). Because of command timeouts in my environment, I couldn't capture the output, including important diagnostic logs for the hang and confirmation of these latest fixes, during my last testing attempt.

Further work is critically needed to:
1.  **Capture logs from the hanging application.** This is my highest priority. One approach could be to redirect stdout/stderr to a file during execution and then examine that file.
2.  Resolve the application hang.
3.  Analyze `qtpy` diagnostic output (once I can obtain it) and resolve any `ModuleNotFoundError`.
4.  Fully test all applied fixes and your application's UI once the hang and Qt platform issues are resolved.