### PR TITLE
I've added extensive logging for UI initialization and navigation.

### DIFF
--- a/grazr/ui/header.py
+++ b/grazr/ui/header.py
@@ -36,10 +36,11 @@ class HeaderWidget(QWidget):
 
     def add_action_widget(self, widget: QWidget):
         """Adds a widget (e.g., a button or a small layout of buttons) to the right side of the header."""
+        logger.debug(f"HEADER.add_action_widget: Adding widget: {widget.__class__.__name__ if widget else 'None'}")
         if widget:
             self.header_actions_layout.addWidget(widget)
             self._action_widgets.append(widget)
-            logger.debug(f"Added action widget: {widget.__class__.__name__}")
+            # logger.debug(f"Added action widget: {widget.__class__.__name__}") # This is redundant with the one above now
         else:
             logger.warning("Attempted to add a None widget to header actions.")
 
@@ -81,6 +82,7 @@ class HeaderWidget(QWidget):
         # (or manage it more carefully if widgets could be added/removed outside this class)
         self._action_widgets = []
         logger.debug("Cleared all action widgets from header.")
+        logger.debug(f"HEADER.clear_actions: Completed. Attempted to remove widgets from layout. Layout count now: {self.header_actions_layout.count()}")
 
     # If specific actions are always present but just shown/hidden, methods could be:
     # def show_action_x(self, visible=True):

--- a/grazr/ui/main_window.py
+++ b/grazr/ui/main_window.py
@@ -346,24 +346,32 @@ class MainWindow(QMainWindow):
     @Slot(int)
     def change_page(self, row: int): # row is emitted by SidebarWidget.navigationItemClicked
         """Changes the current page in the QStackedWidget and updates the header."""
+        logger.debug(f"MAIN_WINDOW.change_page: Received page_key_or_index: {row}")
+        logger.debug(f"SIDEBAR: Emitting pageSelected signal with key/index: {row}") # Logging effective emission
+
         if 0 <= row < self.stacked_widget.count():
             # 1. Get page title from sidebar item text
             sidebar_item = self.sidebar_widget.item(row) # Use new sidebar_widget
             page_title = sidebar_item.text().strip() if sidebar_item else "Unknown Page"
 
             # 2. Set title on HeaderWidget
+            logger.debug(f"MAIN_WINDOW.change_page: Setting header title to: {page_title}")
             self.header_widget.set_title(page_title)
 
             # 3. Clear any actions from the previous page in HeaderWidget
+            logger.debug("MAIN_WINDOW.change_page: Clearing header actions.")
             self.header_widget.clear_actions()
 
             # 4. Set the current page in QStackedWidget
+            logger.debug(f"MAIN_WINDOW.change_page: Attempting to set stacked_widget current index to: {row}")
             self.stacked_widget.setCurrentIndex(row)
+            logger.debug(f"MAIN_WINDOW.change_page: stacked_widget current index set. Current widget: {self.stacked_widget.currentWidget().__class__.__name__}")
 
             # 5. Get the current page widget
             current_page_widget = self.stacked_widget.currentWidget()
 
             # 6. If page has 'add_header_actions', call it
+            logger.debug(f"MAIN_WINDOW.change_page: Asking page {current_page_widget.__class__.__name__} to add its header actions.")
             if hasattr(current_page_widget, 'add_header_actions') and callable(current_page_widget.add_header_actions):
                 current_page_widget.add_header_actions(self.header_widget) # Pass HeaderWidget instance
             else:

--- a/grazr/ui/services_page.py
+++ b/grazr/ui/services_page.py
@@ -123,6 +123,7 @@ class ServicesPage(QWidget):
         title.setFont(QFont("Sans Serif", 11, QFont.Weight.Bold))
 
         self.stop_all_button = QPushButton("Stop All")
+        logger.debug(f"SERVICES_PAGE.__init__: stop_all_button instantiated: {self.stop_all_button}")
         try:
             self.stop_all_button.setIcon(QIcon(":/icons/stop.svg"))
         except:
@@ -133,13 +134,18 @@ class ServicesPage(QWidget):
         self.stop_all_button.setIconSize(QSize(16, 16))
         self.stop_all_button.setFlat(True)
         self.stop_all_button.clicked.connect(self.stopAllServicesClicked.emit)
+
         self.add_service_button = QPushButton("Add Service")
+        logger.debug(f"SERVICES_PAGE.__init__: add_service_button instantiated: {self.add_service_button}")
         self.add_service_button.setObjectName("PrimaryButton")
         self.add_service_button.clicked.connect(self.addServiceClicked.emit)
+
         top_bar_layout.addWidget(title)
         top_bar_layout.addStretch()
         top_bar_layout.addWidget(self.add_service_button)
+        logger.debug(f"SERVICES_PAGE.__init__: add_service_button added to layout. Parent: {self.add_service_button.parentWidget()}")
         top_bar_layout.addWidget(self.stop_all_button)
+        logger.debug(f"SERVICES_PAGE.__init__: stop_all_button added to layout. Parent: {self.stop_all_button.parentWidget()}")
         left_layout.addLayout(top_bar_layout)
         # --- End Top Bar ---
 
@@ -447,7 +453,17 @@ class ServicesPage(QWidget):
 
     @Slot(bool)
     def set_controls_enabled(self, enabled):
-        logger.info(f"SERVICES_PAGE: Setting controls enabled state: {enabled}")
+        logger.debug(f"SERVICES_PAGE.set_controls_enabled(enabled={enabled}) called.")
+        if hasattr(self, 'add_service_button') and self.add_service_button:
+            logger.debug(f"SERVICES_PAGE: add_service_button instance: {self.add_service_button}, parent: {self.add_service_button.parentWidget()}")
+        else:
+            logger.debug(f"SERVICES_PAGE: add_service_button not found or is None at start of set_controls_enabled.")
+        if hasattr(self, 'stop_all_button') and self.stop_all_button:
+            logger.debug(f"SERVICES_PAGE: stop_all_button instance: {self.stop_all_button}, parent: {self.stop_all_button.parentWidget()}")
+        else:
+            logger.debug(f"SERVICES_PAGE: stop_all_button not found or is None at start of set_controls_enabled.")
+
+        logger.info(f"SERVICES_PAGE: Setting controls enabled state (actual logic): {enabled}") # Changed original log to avoid confusion
         if hasattr(self, 'service_widgets') and self.service_widgets:
             for sid, widget in self.service_widgets.items():
                 try:

--- a/grazr/ui/sidebar.py
+++ b/grazr/ui/sidebar.py
@@ -99,6 +99,14 @@ class SidebarWidget(QWidget):
 
         # Connect signal
         self.nav_list_widget.currentRowChanged.connect(self.navigationItemClicked.emit)
+        self.nav_list_widget.itemClicked.connect(self._on_sidebar_item_clicked) # For logging
+
+    @Slot(QListWidgetItem)
+    def _on_sidebar_item_clicked(self, item: QListWidgetItem):
+        if item: # Check if item is not None
+            logger.debug(f"SIDEBAR: Item clicked: {item.text()}, Row: {self.nav_list_widget.row(item)}")
+            # Note: navigationItemClicked is emitted by currentRowChanged, not directly here.
+            # This slot is purely for logging the click itself.
 
     def setCurrentRow(self, row: int):
         self.nav_list_widget.setCurrentRow(row)


### PR DESCRIPTION
This includes detailed diagnostic logging in the following files:
- `grazr/ui/services_page.py`:
    - In `__init__` to log instantiation and parenting of `add_service_button` and `stop_all_button`.
    - At the beginning of `set_controls_enabled` to log the state and parentage of these buttons.
- `grazr/ui/sidebar.py`:
    - In the item click handler to log the clicked item and emitted signal.
- `grazr/ui/main_window.py`:
    - In `change_page` to log received signals, index changes, and calls to header methods.
- `grazr/ui/header.py`:
    - In `clear_actions` to log completion and layout count.
    - In `add_action_widget` to log actions being added.

These changes were made to investigate reports of missing buttons on the ServicesPage and broken page navigation.

Previously, I addressed issues including:
- Handling of Node.js services on the ServicesPage (special "nvm_managed" process_id_for_pm, suppression of related warnings, ServiceItemWidget adjustments).
- Fixes for AttributeError related to ServiceDefinition.
- Safeguards for RuntimeError (deleted C++ objects) in Header and ServicesPage.
- Various ImportErrors, NameErrors.
- Linting errors.
- Attempts to resolve Qt XCB platform plugin errors.
- Initial diagnostic logging for startup and `qtpy` issues.

CRITICAL UNRESOLVED ISSUE:
The application currently hangs during startup when run with `python -m grazr.main` (even with `QT_QPA_PLATFORM="minimal"`). Due to command timeouts, I couldn't capture output (including all the critical diagnostic logs added in this and previous changes) during my last testing attempt.

Further work is critically needed to:
1.  **Capture logs from the hanging application.** This is the highest priority. One method could be redirecting stdout/stderr to a file during execution and then examining its contents.
2.  Resolve the application hang using the captured logs.
3.  Analyze `qtpy` diagnostic output (once obtainable) and resolve any `ModuleNotFoundError`.
4.  Verify all fixes related to button visibility, page navigation, and other UI behaviors using the captured logs.
5.  Fully test the application in its intended GUI environment once the hang and Qt platform issues are resolved.